### PR TITLE
Add '.cuh' to regex of header file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a [GitHub Action](//help.github.com/en/actions) to check for
 `#include` guards in C/C++ header files.
 
-We consider files with extensions `.h`, `.H`, `.hh`, `.hpp`, and `.hxx`
+We consider files with extensions `.h`, `.H`, `.hh`, `.hpp`, `.cuh` and `.hxx`
 as header files.
 In these files we check for the existence of constructs like
 ```c

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,7 +70,7 @@ fail () {
 	ret=1
 }
 
-for header in $(find . -regex '.\+\.\(h\|H\|hh\|hpp\|hxx\)' |
+for header in $(find . -regex '.\+\.\(h\|H\|hh\|hpp\|hxx\|cuh\)' |
 			sed -e 's/^\.\///' |
 			grep -e "$INPUT_ONLY" |
 			grep -v -e '^.git/' ${INPUT_IGNORE:+-e} ${INPUT_IGNORE:+"$INPUT_IGNORE"})
@@ -85,6 +85,6 @@ do
 		fail "$header" "$guard"
 done
 
-echo "::set-output name=fails::$failed"
+echo "fails=$failed" >> $GITHUB_OUTPUT
 
 exit $ret


### PR DESCRIPTION
This PR adds the `.cuh` extension to the regex of header files to be checked.  `.cuh` is the standard header extension for CUDA-C/C++.